### PR TITLE
feat: rename quicksuggest pref for Firefox 95

### DIFF
--- a/user.js
+++ b/user.js
@@ -51,7 +51,7 @@ user_pref("browser.search.suggest.enabled", false);
 user_pref("browser.urlbar.showSearchSuggestionsFirst", false);
 user_pref("browser.urlbar.speculativeConnect.enabled", false);
 user_pref("browser.urlbar.suggest.searches", false);
-user_pref("browser.urlbar.suggest.quicksuggest", false);
+user_pref("browser.urlbar.suggest.quicksuggest.nonsponsored", false);
 user_pref("browser.urlbar.suggest.quicksuggest.sponsored", false);
 /* Disable health reports */
 user_pref("datareporting.healthreport.uploadEnabled", false);


### PR DESCRIPTION
In Firefox 95, `browser.urlbar.suggest.quicksuggest` was replaced by `browser.urlbar.suggest.quicksuggest.nonsponsored` according to https://github.com/arkenfox/user.js/issues/1292