### PR TITLE
feat: disable browser uitour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.0.16](https://github.com/fboulnois/user.js/compare/v1.0.15...v1.0.16) - 2023-06-30
+
+### Added
+
+* Disable browser uitour
+
 ## [v1.0.15](https://github.com/fboulnois/user.js/compare/v1.0.14...v1.0.15) - 2023-04-26
 
 ### Fixed

--- a/user.js
+++ b/user.js
@@ -51,6 +51,8 @@ user_pref("browser.promo.focus.enabled", false);
 user_pref("browser.vpn_promo.enabled", false);
 /* Disable search suggestions */
 user_pref("browser.search.suggest.enabled", false);
+/* Prevent remote resources from interacting with Firefox chrome */
+user_pref("browser.uitour.enabled", false);
 /* Disable location bar suggestions */
 user_pref("browser.urlbar.quicksuggest.enabled", false);
 user_pref("browser.urlbar.speculativeConnect.enabled", false);


### PR DESCRIPTION
`Mozilla.UITour` allows remote resources to interact with the Firefox chrome on whitelisted domains, which is a potential attack vector. Disable this functionality.