### PR TITLE
refactor: move promos to user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.0.17](https://github.com/fboulnois/user.js/compare/v1.0.16...v1.0.17) - 2023-09-12
+
+### Changed
+
+* Move promos from security to user settings
+
 ## [v1.0.16](https://github.com/fboulnois/user.js/compare/v1.0.15...v1.0.16) - 2023-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ more information about `user.js` scripts.
 ## Configured settings
 
 A few user options are configured including setting Firefox as the default
-browser and hiding the bookmarks toolbar.
+browser, hiding the bookmarks toolbar, and removing in-browser advertising.
 
 Mozilla has increasingly relied on data collection to guide Firefox development
 and eroded user privacy in the process. For privacy, data collection is disabled

--- a/user.js
+++ b/user.js
@@ -6,6 +6,10 @@ user_pref("browser.aboutConfig.showWarning", false);
 user_pref("browser.aboutwelcome.enabled", false);
 /* Remove default pinned tabs */
 user_pref("browser.newtabpage.pinned", []);
+/* Disable More from Mozilla tab in settings */
+user_pref("browser.preferences.moreFromMozilla", false);
+/* Disable Firefox Focus promo when private browsing */
+user_pref("browser.promo.focus.enabled", false);
 /* Check that Firefox is the default browser */
 user_pref("browser.shell.checkDefaultBrowser", true);
 /* Skip What's New page after update */
@@ -18,6 +22,8 @@ user_pref("browser.tabs.warnOnOpen", false);
 user_pref("browser.taskbar.previews.enable", true);
 /* Hide bookmark toolbar */
 user_pref("browser.toolbars.bookmarks.visibility", "never");
+/* Disable VPN sponsor when private browsing */
+user_pref("browser.vpn_promo.enabled", false);
 /* Enable custom stylesheets */
 user_pref("toolkit.legacyUserProfileCustomizations.stylesheets", true);
 /* Highlight items when finding in page */
@@ -43,12 +49,6 @@ user_pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
 user_pref("browser.newtabpage.activity-stream.showSponsored", false);
 user_pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);
 user_pref("browser.newtabpage.activity-stream.telemetry", false);
-/* Disable More from Mozilla tab in settings */
-user_pref("browser.preferences.moreFromMozilla", false);
-/* Disable Firefox Focus promo when private browsing */
-user_pref("browser.promo.focus.enabled", false);
-/* Disable VPN sponsor when private browsing */
-user_pref("browser.vpn_promo.enabled", false);
 /* Disable search suggestions */
 user_pref("browser.search.suggest.enabled", false);
 /* Prevent remote resources from interacting with Firefox chrome */


### PR DESCRIPTION
Security settings should not include disabling the Firefox in-browser advertisements, and these should be considered user settings instead.