### PR TITLE
Remove old unused Firefox 115 preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.0.19](https://github.com/fboulnois/user.js/compare/v1.0.18...v1.0.19) - 2024-03-08
+
+### Fixed
+
+* Remove old formautofill heuristics pref
+* Remove old activity feed snippets pref
+
 ## [v1.0.18](https://github.com/fboulnois/user.js/compare/v1.0.17...v1.0.18) - 2023-11-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Firefox `user.js`
 
 A custom [`user.js`](user.js) script to configure Firefox user, privacy, and
-security settings. Supports Firefox 112+.
+security settings. Supports Firefox 115+.
 
 The goal is to make minimal changes to Firefox settings to enhance security and
 privacy without compromising on modern web features or making Firefox unstable

--- a/user.js
+++ b/user.js
@@ -45,7 +45,6 @@ user_pref("browser.contentblocking.category", "strict");
 user_pref("browser.formfill.enable", false);
 /* Disable activity stream */
 user_pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
-user_pref("browser.newtabpage.activity-stream.feeds.snippets", false);
 user_pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
 user_pref("browser.newtabpage.activity-stream.showSponsored", false);
 user_pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);

--- a/user.js
+++ b/user.js
@@ -66,7 +66,6 @@ user_pref("dom.security.https_only_mode", true);
 /* Disable form autofill */
 user_pref("extensions.formautofill.addresses.enabled", false);
 user_pref("extensions.formautofill.creditCards.enabled", false);
-user_pref("extensions.formautofill.heuristics.enabled", false);
 /* Disable pocket extension */
 user_pref("extensions.pocket.enabled", false);
 /* Disable link and DNS prefetching */


### PR DESCRIPTION
These preferences are no longer relevant.