### PR TITLE
feat: do not suggest search engines in urlbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.0.20](https://github.com/fboulnois/user.js/compare/v1.0.19...v1.0.20) - 2024-04-06
+
+### Added
+
+* Do not suggest search engines in urlbar
+
 ## [v1.0.19](https://github.com/fboulnois/user.js/compare/v1.0.18...v1.0.19) - 2024-03-08
 
 ### Fixed

--- a/user.js
+++ b/user.js
@@ -56,6 +56,7 @@ user_pref("browser.uitour.enabled", false);
 /* Disable location bar suggestions */
 user_pref("browser.urlbar.quicksuggest.enabled", false);
 user_pref("browser.urlbar.speculativeConnect.enabled", false);
+user_pref("browser.urlbar.suggest.engines", false);
 user_pref("browser.urlbar.suggest.searches", false);
 /* Disable health reports */
 user_pref("datareporting.healthreport.uploadEnabled", false);


### PR DESCRIPTION
By default, search engines are shown while searching from the urlbar. Disable this behavior.