### PR TITLE
feat: disable PPA submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.0.21](https://github.com/fboulnois/user.js/compare/v1.0.20...v1.0.21) - 2024-07-13
+
+### Added
+
+* Disable PPA submissions
+
 ## [v1.0.20](https://github.com/fboulnois/user.js/compare/v1.0.19...v1.0.20) - 2024-04-06
 
 ### Added

--- a/user.js
+++ b/user.js
@@ -62,6 +62,8 @@ user_pref("browser.urlbar.suggest.searches", false);
 user_pref("datareporting.healthreport.uploadEnabled", false);
 /* Disable data submission */
 user_pref("datareporting.policy.dataSubmissionEnabled", false);
+/* Disable privacy-preserving attribution submissions */
+user_pref("dom.private-attribution.submission.enabled", false);
 /* Enable https only mode */
 user_pref("dom.security.https_only_mode", true);
 /* Disable form autofill */


### PR DESCRIPTION
Privacy-preserving attribution (PPA) sends reports which include ad impressions and destination websites to a third-party.